### PR TITLE
Fixed tflint and checkov warnings

### DIFF
--- a/ter-homeworks/05/src/.tflint.hcl
+++ b/ter-homeworks/05/src/.tflint.hcl
@@ -1,0 +1,10 @@
+config {
+  format = "compact"
+  plugin_dir = "~/.tflint.d/plugins"
+  module = true
+}
+
+plugin "terraform" {
+  enabled = true
+  preset = "recommended"
+}

--- a/ter-homeworks/05/src/main.tf
+++ b/ter-homeworks/05/src/main.tf
@@ -27,15 +27,16 @@ module "vpc" {
 # }
 
 module "marketing_vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
-  env_name       = "develop"
-  network_id     = module.vpc.network_id
-  subnet_zones   = [ module.vpc.zone ]
-  subnet_ids     = [ module.vpc.subnet_id ]
-  instance_name  = "marketing-web"
-  instance_count = 1
-  image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  source             = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
+  env_name           = "develop"
+  network_id         = module.vpc.network_id
+  subnet_zones       = [ module.vpc.zone ]
+  subnet_ids         = [ module.vpc.subnet_id ]
+  instance_name      = "marketing-web"
+  instance_count     = 1
+  image_family       = "ubuntu-2004-lts"
+  public_ip          = false
+  security_group_ids = [ yandex_vpc_security_group.example.id ]
 
   # # для задания 4*
   # source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
@@ -63,15 +64,16 @@ module "marketing_vm" {
 }
 
 module "analytics_vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
-  env_name       = "develop"
-  network_id     = module.vpc.network_id
-  subnet_zones   = [ module.vpc.zone ]
-  subnet_ids     = [ module.vpc.subnet_id ]
-  instance_name  = "analytics-web"
-  instance_count = 1
-  image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  source             = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
+  env_name           = "develop"
+  network_id         = module.vpc.network_id
+  subnet_zones       = [ module.vpc.zone ]
+  subnet_ids         = [ module.vpc.subnet_id ]
+  instance_name      = "analytics-web"
+  instance_count     = 1
+  image_family       = "ubuntu-2004-lts"
+  public_ip          = false
+  security_group_ids = [ yandex_vpc_security_group.example.id ]
 
   # # для задания 4*
   # source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

--- a/ter-homeworks/05/src/providers.tf
+++ b/ter-homeworks/05/src/providers.tf
@@ -2,7 +2,13 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.90.0"
     }
+    
+    template = {
+      source  = "hashicorp/template"
+      version = "2.2.0"
+    }  
   }
 
   backend "s3" {

--- a/ter-homeworks/05/src/security.tf
+++ b/ter-homeworks/05/src/security.tf
@@ -1,0 +1,84 @@
+variable "security_group_ingress" {
+  description = "secrules ingress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий ssh"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 22
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий  http"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 80
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий https"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 443
+    },
+  ]
+}
+
+variable "security_group_egress" {
+  description = "secrules egress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    { 
+      protocol       = "TCP"
+      description    = "разрешить весь исходящий трафик"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      from_port      = 0
+      to_port        = 65365
+    }
+  ]
+}
+
+resource "yandex_vpc_security_group" "example" {
+  name       = "example_dynamic"
+  network_id = module.vpc.network_id
+  folder_id  = var.folder_id
+
+  dynamic "ingress" {
+    for_each = var.security_group_ingress
+    content {
+      protocol       = lookup(ingress.value, "protocol", null)
+      description    = lookup(ingress.value, "description", null)
+      port           = lookup(ingress.value, "port", null)
+      from_port      = lookup(ingress.value, "from_port", null)
+      to_port        = lookup(ingress.value, "to_port", null)
+      v4_cidr_blocks = lookup(ingress.value, "v4_cidr_blocks", null)
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.security_group_egress
+    content {
+      protocol       = lookup(egress.value, "protocol", null)
+      description    = lookup(egress.value, "description", null)
+      port           = lookup(egress.value, "port", null)
+      from_port      = lookup(egress.value, "from_port", null)
+      to_port        = lookup(egress.value, "to_port", null)
+      v4_cidr_blocks = lookup(egress.value, "v4_cidr_blocks", null)
+    }
+  }
+}

--- a/ter-homeworks/05/src/variables.tf
+++ b/ter-homeworks/05/src/variables.tf
@@ -36,7 +36,7 @@ variable ssh_public_key {
 #   default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIOERolx3KtJ5+3FufMC88MhcYISKmL28lYydyc4MGYV udjin@udjin-VirtualBox"
 # }
 
-variable "allow_stopping_for_update" {
-  type = bool
-  default = true
-}
+# variable "allow_stopping_for_update" {
+#   type = bool
+#   default = true
+# }


### PR DESCRIPTION
**tflint**
```
kiv@netology:~/VSC/devops-netology/ter-homeworks/05/src$ docker run --rm -v "$(pwd):/tflint" ghcr.io/terraform-linters/tflint --chdir /tflint
kiv@netology:~/VSC/devops-netology/ter-homeworks/05/src$ 


kiv@netology:~/VSC/devops-netology/ter-homeworks/05/src$ docker run --rm --tty --volume $(pwd):/tf --workdir /tf bridgecrew/checkov --download-external-modules true --directory /tf
```
**checkov**
```
       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.20 
Update available 3.2.20 -> 3.2.21
Run pip3 install -U checkov to update 


terraform scan results:

Passed checks: 9, Failed checks: 0, Skipped checks: 0

Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.analytics_vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:66-101
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.analytics_vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:66-101
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.analytics_vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:66-101
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.marketing_vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:29-64
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.marketing_vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:29-64
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.marketing_vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:29-64
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: marketing_vm
        File: /main.tf:29-64
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: analytics_vm
        File: /main.tf:66-101
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_YC_19: "Ensure security group does not contain allow-all rules."
        PASSED for resource: yandex_vpc_security_group.example
        File: /security.tf:56-84
```

**terraform plan**
```
kiv@netology:~/VSC/devops-netology/ter-homeworks/05/src$ terraform plan
Acquiring state lock. This may take a few moments...
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=b80abb40bec647dc542585ac879818e929c9f9b2e1bf852a73bfb9ea436d8af7]
module.marketing_vm.data.yandex_compute_image.my_image: Reading...
module.vpc.yandex_vpc_network.network: Refreshing state... [id=enpo9tl99p980ub9t552]
module.analytics_vm.data.yandex_compute_image.my_image: Reading...
module.marketing_vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd8bt3r9v1tq5fq7jcna]
module.analytics_vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd8bt3r9v1tq5fq7jcna]
module.vpc.yandex_vpc_subnet.subnet: Refreshing state... [id=e9bupkea4ig3e0mljaic]
module.marketing_vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhm0gl4eus5brru71q9r]
module.analytics_vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmg0gpk6f6l7r1gsni1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # yandex_vpc_security_group.example will be created
  + resource "yandex_vpc_security_group" "example" {
      + created_at = (known after apply)
      + folder_id  = "b1gkbq3nbsragp4t759r"
      + id         = (known after apply)
      + labels     = (known after apply)
      + name       = "example_dynamic"
      + network_id = "enpo9tl99p980ub9t552"
      + status     = (known after apply)

      + egress {
          + description    = "разрешить весь исходящий трафик"
          + from_port      = 0
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = -1
          + protocol       = "TCP"
          + to_port        = 65365
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }

      + ingress {
          + description    = "разрешить входящий  http"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 80
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
      + ingress {
          + description    = "разрешить входящий https"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 443
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
      + ingress {
          + description    = "разрешить входящий ssh"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 22
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
    }

  # module.analytics_vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmg0gpk6f6l7r1gsni1"
        name                      = "develop-analytics-web-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.marketing_vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhm0gl4eus5brru71q9r"
        name                      = "develop-marketing-web-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.
```